### PR TITLE
Small update to GameStats.js view

### DIFF
--- a/src/components/sections/GameStats.js
+++ b/src/components/sections/GameStats.js
@@ -90,7 +90,7 @@ class GameStats extends React.Component {
         : "Our Saving Pool is live!",
       paragraph: props.isJoinable
         ? ""
-        : "👉 Don't forget to make your recurring deposit to stay alive!",
+        : "👉 Don't forget to make your recurring deposits to stay alive!",
     };
     const numberOfPlayers = (status) => {
       const conditions = {
@@ -137,9 +137,8 @@ class GameStats extends React.Component {
       },
       {
         label: "Players Status",
-        data: ` Live: ${numberOfPlayers("alive")} Dead: ${numberOfPlayers(
-          "dead"
-        )} `,
+        data: `${numberOfPlayers("alive")} Alive & ${numberOfPlayers(
+          "dead")} Dead`,
         condition: !props.hidePlayersStatus,
       },
     ];
@@ -172,7 +171,7 @@ class GameStats extends React.Component {
                       style={{ textAlign: "left" }}
                     >
                       <h3 style={{ marginTop: "5px" }}>
-                        Game Stats 
+                        Game Stats {' '}
                         <span role="img" aria-label="game emoji">
                           👾
                         </span>

--- a/src/components/sections/GameStats.js
+++ b/src/components/sections/GameStats.js
@@ -84,13 +84,13 @@ class GameStats extends React.Component {
 
     const sectionHeader = {
       title: props.isJoinable
-        ? `Our saving pool closes in ${dayjs().to(
+        ? `Our Saving Pool closes ${dayjs().to(
             props.gameInfo.firstSegmentEnd
           )}`
         : "Our Saving Pool is live!",
       paragraph: props.isJoinable
         ? ""
-        : "👉Don't forget to make your regular deposit!",
+        : "👉 Don't forget to make your recurring deposit to stay alive!",
     };
     const numberOfPlayers = (status) => {
       const conditions = {
@@ -109,23 +109,31 @@ class GameStats extends React.Component {
 
     const gameData = [
       {
-        label: "Regular deposit",
+        label: "⏳ Current Round",
+        data: !this.props.gameInfo.isGameCompleted
+          ? `${displaySegment(
+              this.props.gameInfo.currentSegment
+            )} out of ${displaySegment(this.props.gameInfo.lastSegment)}`
+          : "Game Completed ✔️",
+      },
+      {
+        label: "🎯 Recurring Deposit",
         data: `${web3.utils.fromWei(
           this.props.gameInfo.rawSegmentPayment
         )} DAI`,
       },
       {
-        label: "Total Pool Amount",
+        label: "🏦 Total Pool Funds",
         data: `${
           this.props.gameInfo &&
           weiToERC20(this.props.gameInfo.totalGamePrincipal)
         } DAI`,
       },
       {
-        label: "Total Pool Interest",
+        label: "💸 Total Pool Interest",
         data: `${
           this.props.gameInfo && weiToERC20(this.props.totalGameInterest)
-        } DAI`,
+        } DAI`, //🚨 would be nice if this can show more decimals! 
       },
       {
         label: "Players Status",
@@ -133,14 +141,6 @@ class GameStats extends React.Component {
           "dead"
         )} `,
         condition: !props.hidePlayersStatus,
-      },
-      {
-        label: "Current Round",
-        data: !this.props.gameInfo.isGameCompleted
-          ? `${displaySegment(
-              this.props.gameInfo.currentSegment
-            )} / ${displaySegment(this.props.gameInfo.lastSegment)}`
-          : "Game Completed",
       },
     ];
 
@@ -172,7 +172,7 @@ class GameStats extends React.Component {
                       style={{ textAlign: "left" }}
                     >
                       <h3 style={{ marginTop: "5px" }}>
-                        Game Stats
+                        Game Stats 
                         <span role="img" aria-label="game emoji">
                           👾
                         </span>


### PR DESCRIPTION
- Re-arranged 'Current Round' to be at the top of the Game Stats.
  & changed the notation from round "1 / 3" to "1 out of 3".

- Slightly changed text: e.g. 'recurring' instead of 'regular' 

- Removed double "in" which was displayed on top of the game stats  (since dayjs() already types "in" if I am not mistaking)
e.g. where it previously displayed `our saving pool closes in in 2 minutes` this now should be `our saving pool closes in 2 minutes` 

- Added emoji's for each item

- Added a space between 'Game Stats' and '👾'