### PR TITLE
Updated PlayerInfo.js

### DIFF
--- a/src/components/elements/PlayerInfo.js
+++ b/src/components/elements/PlayerInfo.js
@@ -7,7 +7,7 @@ const PlayerInfo = (props) => {
   const humanMostRecentSegmentPaid =
     parseInt(props.playerInfo.mostRecentSegmentPaid) + 1;
   const humanTotalDepositsNeeded =
-    parseInt(props.gameInfo.lastSegment) - 1; 
+    parseInt(props.lastSegment);
   const getPlayerFromPlayers = () =>
     props.players.filter((player) => {
       return (
@@ -20,9 +20,10 @@ const PlayerInfo = (props) => {
     paddingLeft: "15px",
     paddingRight: "15px",
     borderRadius: "3px",
-    fontFamily: "monospace",
+    fontFamily: "monospace, monospace",
     fontSize: "0.85rem",
     marginLeft: "0px",
+    color: "#333366"
   };
   return (
     <div
@@ -80,8 +81,8 @@ const PlayerInfo = (props) => {
           <span style={valueStyle}>
             {parseInt(props.lastSegment) - 1 ===
             parseInt(props.playerInfo.mostRecentSegmentPaid)
-              ? "Winner 🥳 you made all deposits and earned a slice of the interest"
-              : "Defeated 😢 you missed a deposit and did not earn a slice of the interest this time"}
+              ? "WINNER 🥳 you made all deposits and earned a slice of the interest"
+              : "DEFEATED 😢 you missed a deposit and did not earn a slice of the interest this time"}
           </span>
         )}
       </div>
@@ -90,20 +91,20 @@ const PlayerInfo = (props) => {
             className="sans_serif"
             style={{ fontWeight: "600", fontSize: "0.85rem" }}
           >
-            Amount Deposited:
+            Deposits made:
           </span>{" "}
-          <span style={valueStyle}>
-            {weiToERC20(props.playerInfo.amountPaid)} DAI
-          </span>
+          <span style={valueStyle}>{humanMostRecentSegmentPaid} (out of {humanTotalDepositsNeeded})</span>
         </div>
         <div>
           <span
             className="sans_serif"
             style={{ fontWeight: "600", fontSize: "0.85rem" }}
           >
-            Succesfull Deposits:
+            Total Deposited:
           </span>{" "}
-          <span style={valueStyle}>{humanMostRecentSegmentPaid} (out of {humanTotalDepositsNeeded})</span>  //🚨 Not sure if this formatting works
+          <span style={valueStyle}>
+            {weiToERC20(props.playerInfo.amountPaid)} DAI
+          </span>
         </div>
         <div>
           <span

--- a/src/components/elements/PlayerInfo.js
+++ b/src/components/elements/PlayerInfo.js
@@ -6,6 +6,8 @@ import { weiToERC20 } from "./../../utils/utilities";
 const PlayerInfo = (props) => {
   const humanMostRecentSegmentPaid =
     parseInt(props.playerInfo.mostRecentSegmentPaid) + 1;
+  const humanTotalDepositsNeeded =
+    parseInt(props.gameInfo.lastSegment) - 1; 
   const getPlayerFromPlayers = () =>
     props.players.filter((player) => {
       return (
@@ -60,22 +62,35 @@ const PlayerInfo = (props) => {
         )}
       </div>
       <div>
+      <div>
+        <span
+          className="sans_serif"
+          style={{ fontWeight: "600", fontSize: "0.85rem" }}
+        >
+          Status:
+        </span>{" "}
+        {!props.isGameCompleted && (
+          <span style={valueStyle}>
+            {props.playerInfo.isStillInGame
+              ? "Alive 🎉 you made all deposits so far - keep up the good work!"
+              : "Dead 😢 sorry you missed a deposit"}
+          </span>
+        )}
+        {props.isGameCompleted && (
+          <span style={valueStyle}>
+            {parseInt(props.lastSegment) - 1 ===
+            parseInt(props.playerInfo.mostRecentSegmentPaid)
+              ? "Winner 🥳 you made all deposits and earned a slice of the interest"
+              : "Defeated 😢 you missed a deposit and did not earn a slice of the interest this time"}
+          </span>
+        )}
+      </div>
         <div>
           <span
             className="sans_serif"
             style={{ fontWeight: "600", fontSize: "0.85rem" }}
           >
-            {" "}
-            ETH address{" "}
-          </span>{" "}
-          : <span style={valueStyle}>{props.playerInfo.address}</span>
-        </div>
-        <div>
-          <span
-            className="sans_serif"
-            style={{ fontWeight: "600", fontSize: "0.85rem" }}
-          >
-            Amount Paid:
+            Amount Deposited:
           </span>{" "}
           <span style={valueStyle}>
             {weiToERC20(props.playerInfo.amountPaid)} DAI
@@ -86,32 +101,19 @@ const PlayerInfo = (props) => {
             className="sans_serif"
             style={{ fontWeight: "600", fontSize: "0.85rem" }}
           >
-            Most Recent Segment Paid:
+            Succesfull Deposits:
           </span>{" "}
-          <span style={valueStyle}>{humanMostRecentSegmentPaid}</span>
+          <span style={valueStyle}>{humanMostRecentSegmentPaid} (out of {humanTotalDepositsNeeded})</span>  //🚨 Not sure if this formatting works
         </div>
         <div>
           <span
             className="sans_serif"
             style={{ fontWeight: "600", fontSize: "0.85rem" }}
           >
-            Players Status:
+            {" "}
+            ETH address{" "}
           </span>{" "}
-          {!props.isGameCompleted && (
-            <span style={valueStyle}>
-              {props.playerInfo.isStillInGame
-                ? "live 🎉"
-                : "sorry you missed a payment 😢"}
-            </span>
-          )}
-          {props.isGameCompleted && (
-            <span style={valueStyle}>
-              {parseInt(props.lastSegment) - 1 ===
-              parseInt(props.playerInfo.mostRecentSegmentPaid)
-                ? "Winner 🥳"
-                : "Loser 😢"}
-            </span>
-          )}
+          : <span style={valueStyle}>{props.playerInfo.address}</span>
         </div>
       </div>
 


### PR DESCRIPTION
 **Rearranged ordering:**
- Moved 'ETH address' to the bottom, since this is something a users is probably not that interested in
- Moved 'Player Status' to the top, and renamed this to simply 'Status'

 **Reworded some stuff** e.g. Loser --> Defeated

**Now also showing how many deposits a user will have to make in total**  (via `humanTotalDepositsNeeded` ) 

**Made text slightly more readable**