### PR TITLE
Change approval back to original (wasn't working) 

### DIFF
--- a/src/views/Game.js
+++ b/src/views/Game.js
@@ -183,7 +183,7 @@ const GamePage = () => {
       firstSegmentStartArr: dayjs.unix(firstSegmentStart).toArray(),
       segmentPayment: segmentPayment / 10 ** 18,
       rawSegmentPayment: segmentPayment,
-      cumulativeSegmentPayments: String(segmentPayment * lastSegment),
+      //cumulativeSegmentPayments: String(segmentPayment * lastSegment), TODO: FIX WHY THIS RETURNS INVALID_ARGUMENT WHEN >1000 
       segmentLengthInSecs: segmentLength,
       segmentLength: dayjs.duration(segmentLength * 1000),
       currentSegment,
@@ -206,10 +206,10 @@ const GamePage = () => {
       const web3 = new Web3(window.ethereum);
       setWeb3(web3);
     }
-    //const daiContract = new web3.eth.Contract(DaiABI, daiAddress);
-    //await daiContract.methods
-    //  .approve(goodGhostingAdress, gameInfo.rawSegmentPayment) //should no longer be needed anymore for new games - but keep until tested
-    //  .send({ from: usersAddress });
+    const daiContract = new web3.eth.Contract(DaiABI, daiAddress);
+    await daiContract.methods
+      .approve(goodGhostingAdress, gameInfo.rawSegmentPayment)
+      .send({ from: usersAddress });
 
     await goodGhostingContract.methods
       .makeDeposit()
@@ -299,7 +299,7 @@ const GamePage = () => {
 
     const daiContract = new web3.eth.Contract(DaiABI, daiAddress);
     const approve = await daiContract.methods
-      .approve(goodGhostingAdress, gameInfo.cumulativeSegmentPayments)
+      .approve(goodGhostingAdress, gameInfo.rawSegmentPayment)
       .send({ from: usersAddress })
       .then((res) => console.log("res", res))
       .catch((err) => {

--- a/src/views/Game.js
+++ b/src/views/Game.js
@@ -183,6 +183,7 @@ const GamePage = () => {
       firstSegmentStartArr: dayjs.unix(firstSegmentStart).toArray(),
       segmentPayment: segmentPayment / 10 ** 18,
       rawSegmentPayment: segmentPayment,
+      cumulativeSegmentPayments: String(segmentPayment * lastSegment),
       segmentLengthInSecs: segmentLength,
       segmentLength: dayjs.duration(segmentLength * 1000),
       currentSegment,
@@ -205,10 +206,10 @@ const GamePage = () => {
       const web3 = new Web3(window.ethereum);
       setWeb3(web3);
     }
-    const daiContract = new web3.eth.Contract(DaiABI, daiAddress);
-    await daiContract.methods
-      .approve(goodGhostingAdress, gameInfo.rawSegmentPayment)
-      .send({ from: usersAddress });
+    //const daiContract = new web3.eth.Contract(DaiABI, daiAddress);
+    //await daiContract.methods
+    //  .approve(goodGhostingAdress, gameInfo.rawSegmentPayment) //should no longer be needed anymore for new games - but keep until tested
+    //  .send({ from: usersAddress });
 
     await goodGhostingContract.methods
       .makeDeposit()
@@ -298,7 +299,7 @@ const GamePage = () => {
 
     const daiContract = new web3.eth.Contract(DaiABI, daiAddress);
     const approve = await daiContract.methods
-      .approve(goodGhostingAdress, gameInfo.rawSegmentPayment)
+      .approve(goodGhostingAdress, gameInfo.cumulativeSegmentPayments)
       .send({ from: usersAddress })
       .then((res) => console.log("res", res))
       .catch((err) => {


### PR DESCRIPTION
Trying to do the approval during joinGame gave the following error in my browsers console.
So reverted any changes to the approval workflow.

`Index.js:217

Uncaught (in promise) Error: invalid BigNumber string (argument="value", value="1.5e+21", code=INVALID_ARGUMENT, version=bignumber/5.0.7)
at t.value (index.js:217)
at t.value (index.js:228)
at t.value (index.js:233)
at Function.value (bignumber.js:251)
at r.value (number.js:30)
at array.js:45
at Array.forEach ()
at z (array.js:31)
at r.value (tuple.js:37)
at t.value (abi-coder.js:129)`

